### PR TITLE
Procfile: no watch & bind to 0.0.0.0 explicitly

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: jekyll serve -P $PORT
+web: jekyll serve --no-watch -H 0.0.0.0 -P $PORT


### PR DESCRIPTION
In Jekyll 3, we bind to 127.0.0.1 because the quadruple zero's give us issues in Chrome.  Also, don't waste the Dyno time on watching.